### PR TITLE
Fix: Resolve pnpm run pack error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+node-linker=hoisted
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*
+# The above public-hoist-pattern lines are often helpful with hoisted linkers
+# for tools that expect ESLint/Prettier to be easily resolvable.

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,4 +7,3 @@ vsc-extension-quickstart.md
 **/tsconfig.json
 **/.eslintrc.json
 **/*.map
-**/*.ts 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run build",
-    "pack": "npx @vscode/vsce package",
+    "pack": "pnpm dlx @vscode/vsce package",
     "build": "rimraf dist && vite build && pnpm run build:ts --minify",
     "build:ts": "tsup src/extension.ts --external=vscode -d dist",
     "watch": "tsup src/extension.ts --external=vscode -d dist --watch"


### PR DESCRIPTION
The `pnpm run pack` command was failing due to issues with file inclusion and compatibility between pnpm's module layout and the `@vscode/vsce` packaging tool.

This commit addresses the issues by:
1. Modifying `.vscodeignore` to remove the overly broad `**/*.ts` pattern, which could have inadvertently excluded necessary build artifacts.
2. Creating a `.npmrc` file with the setting `node-linker=hoisted`. This configures pnpm to create a `node_modules` structure that is more compatible with tools like `vsce`, resolving issues related to dependency discovery during packaging.
3. Updating the `pack` script in `package.json` to use `pnpm dlx` for executing `@vscode/vsce`.

With these changes, `pnpm run pack` now successfully generates the .vsix extension package.